### PR TITLE
Fixes crash if class contains no properties

### DIFF
--- a/src/main/java/com/kesselring/valuegenerator/GenerateValueClassHandler.java
+++ b/src/main/java/com/kesselring/valuegenerator/GenerateValueClassHandler.java
@@ -56,6 +56,7 @@ public class GenerateValueClassHandler extends EditorActionHandler {
                         new Variable.Name(psiVariable.getName())))
                 .peek(System.out::println)
                 .collect(Collectors.toList());
+        if (extractedVariables.isEmpty()) return;
 
         PsiClassImpl sourceJavaPsiClass = getRootClassUnderOperation(rootPsiFile);
         if (sourceJavaPsiClass == null) return;


### PR DESCRIPTION
Fixes crash if class contains no properties, closes issue #16.